### PR TITLE
fix: Track favicon asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 # Ignore generated artifacts in src/; only keep the entry-point HTML tracked
 src/*
 !src/index.html
+!src/favicon.svg

--- a/src/favicon.svg
+++ b/src/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="ezbugs favicon">
+  <circle cx="32" cy="32" r="28" fill="#090f1d" />
+</svg>


### PR DESCRIPTION
Ensure the repo tracks the favicon by un-ignoring  and adding the file to version control.