### PR TITLE
fix: per-step contract labels in execution flow widgets

### DIFF
--- a/main.py
+++ b/main.py
@@ -587,6 +587,9 @@ def _walk_callable(
             "source": _source_text(item),
             "selector": _function_selector(item),
             "cyclomatic_complexity": compute_cyclomatic_complexity(item) if hasattr(item, "nodes") else 1,
+            "contract": getattr(getattr(item, "contract_declarer", None), "name", None)
+            or getattr(getattr(item, "contract", None), "name", None)
+            or "Unknown",
         }
     )
     callable_index[name] = item

--- a/template.html
+++ b/template.html
@@ -315,7 +315,7 @@
             id: normalizeId(entry.entry_point || `fn_${idx}`, `node${stepIndex}`),
             depth: stepIndex,
             name: step.selector,
-            contractName: entry.contract || 'Unknown',
+            contractName: step.contract || entry.contract || 'Unknown',
             functionName: (step.name || `step_${stepIndex}`).split('.').slice(1).join('.'),
             signature: step.name || '',
             type: stepIndex === 0 ? 'entry-point' : 'internal',


### PR DESCRIPTION
## Summary

- Fixes a bug where every execution-flow widget showed the entry point’s contract name.
- Each flow step now carries its declaring contract name from the analysis output.
- UI uses that per-step contract, so internal calls display the correct contract.