### PR TITLE
new: custom templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ examples/*
 .env
 # AI assistant guidance (local only)
 AGENTS.md
+# User-local scratch files such as custom templates
+local-only/
 # Python bytecode cache
 __pycache__/
 # Ignore generated artifacts in src/; only keep the entry-point HTML tracked

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Create a file named `.env` (or copy `example.env` to `.env`) and add your `ETHER
 ETHERSCAN_API_KEY=...
 ```
 
+Optional: set `TEMPLATE_PATH=path/to/custom-template.html` in `.env` to override the
+default dashboard template. Relative paths are resolved from the repository root. If
+unset, OnboardMe uses [`template.html`](template.html).
+
 ### Read-only contract calls (eth_call) and RPC URLs
 
 The UI includes a **read-only contract call** feature (calls `view` / `pure` functions via `eth_call`).

--- a/analysis/flow_walk.py
+++ b/analysis/flow_walk.py
@@ -1126,10 +1126,12 @@ def _iter_audited_contracts(
             for base in getattr(root, "inheritance", []):
                 allowed_keys.add(_contract_key(base))
 
+    candidates = slither.contracts if allowed_keys is not None else slither.contracts_derived
+
     return sorted(
         (
             contract
-            for contract in slither.contracts_derived
+            for contract in candidates
             if not contract.is_test
             and not contract.is_from_dependency()
             and not is_test_file(Path(contract.source_mapping.filename.absolute))

--- a/analysis/render.py
+++ b/analysis/render.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
+from analysis.slither_env import _load_dotenv
+
 ProgressCallback = Callable[[str, Dict[str, Any] | None], None]
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_TEMPLATE_PATH = _REPO_ROOT / "template.html"
+_TEMPLATE_ENV_VAR = "TEMPLATE_PATH"
 
 
 def _report_progress(callback: ProgressCallback | None, message: str, **meta: Any) -> None:
@@ -52,6 +58,20 @@ def _build_storage_payload(
     return storage_vars, writers_index
 
 
+def _resolve_template_path() -> Path:
+    """Resolve the HTML template path from env, falling back to template.html."""
+    _load_dotenv()
+
+    configured = os.environ.get(_TEMPLATE_ENV_VAR, "").strip()
+    if not configured:
+        return _DEFAULT_TEMPLATE_PATH
+
+    template_path = Path(configured).expanduser()
+    if not template_path.is_absolute():
+        template_path = _REPO_ROOT / template_path
+    return template_path
+
+
 def render_html(
     contract_views: Dict[str, Dict[str, Any]],
     default_contract: str,
@@ -86,8 +106,15 @@ def render_html(
 
     contract_list = sorted(rendered_views.keys())
 
-    template_path = Path("template.html")
-    _report_progress(progress_cb, "Rendering template")
+    template_path = _resolve_template_path()
+    if not template_path.is_file():
+        if template_path == _DEFAULT_TEMPLATE_PATH:
+            raise FileNotFoundError(f"Default template not found: {template_path}")
+        raise FileNotFoundError(
+            f"Configured {_TEMPLATE_ENV_VAR} does not point to a file: {template_path}"
+        )
+
+    _report_progress(progress_cb, "Rendering template", template=str(template_path))
     template_html = template_path.read_text(encoding="utf-8")
 
     views_json = json.dumps(rendered_views, ensure_ascii=False, indent=2)
@@ -117,8 +144,7 @@ def render_html(
     output_dir = output_dir or Path("src")
     output_dir.mkdir(parents=True, exist_ok=True)
     _report_progress(progress_cb, "Writing output")
-    repo_root = Path(__file__).resolve().parent.parent
-    hotkeys_src = repo_root / "src" / "hotkeys.json"
+    hotkeys_src = _REPO_ROOT / "src" / "hotkeys.json"
     hotkeys_dst = output_dir / "hotkeys.json"
     if hotkeys_src.exists():
         # Keep hotkeys in sync with template behavior. Like the HTML file, overwrite on every render.

--- a/example.env
+++ b/example.env
@@ -1,5 +1,9 @@
 # Copy to .env and fill in values.
 
+# Optional: override the default dashboard template. Relative paths are resolved
+# from the repository root. When unset, template.html is used.
+TEMPLATE_PATH=
+
 # Used for contract fetching and (for supported chains) read-only eth_call via Etherscan proxy.
 ETHERSCAN_API_KEY=
 
@@ -18,4 +22,3 @@ RPC_URL_10=
 RPC_URL_11155420=
 RPC_URL_43114=
 RPC_URL_43113=
-

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from analysis.flow_walk import (
     build_read_only_entry_point_flows,
 )
 from analysis.render import render_html
+from analysis.slither_extract import _contract_key
 from analysis.state_vars import (
     _event_record,
     _interface_record,
@@ -58,11 +59,13 @@ def _resolve_contract_name_from_export(address: str, chain: str) -> str | None:
         return None
     prefix = f"{_normalize_address(address)}{chain.lower()}-"
     for entry in export_root.iterdir():
-        if not entry.is_dir():
+        if not entry.is_dir() and entry.suffix.lower() != ".sol":
             continue
         name = entry.name
         if name.lower().startswith(prefix):
             candidate = name[len(prefix):]
+            if candidate.lower().endswith(".sol"):
+                candidate = candidate[:-4]
             return candidate or None
     return None
 
@@ -507,6 +510,32 @@ def _select_local_root_contracts(slither: Slither) -> List[Contract]:
     roots = [contract for contract in audited_contracts if contract not in inherited]
     return roots or audited_contracts
 
+
+def _merge_root_contracts(
+    preferred_contracts: Sequence[Contract] | None,
+    discovered_contracts: Sequence[Contract] | None,
+) -> List[Contract]:
+    """
+    Merge contract lists while preserving order and keeping the deployed contract first.
+
+    On-chain verification bundles can contain multiple deployable contracts. The generic
+    "local roots" heuristic is useful for surfacing sibling contracts, but it must not
+    drop the contract actually deployed at the requested address.
+    """
+    merged: List[Contract] = []
+    seen: set[tuple[str, str]] = set()
+
+    for contract in list(preferred_contracts or []) + list(discovered_contracts or []):
+        if contract is None:
+            continue
+        key = _contract_key(contract)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(contract)
+
+    return merged
+
 # ----------- Main ------------------------------------------------------------
 
 def generate_html(
@@ -564,7 +593,10 @@ def generate_html(
 
     _report_progress(progress_cb, "Resolving deployed contract")
     resolved_contracts = _resolve_root_contracts(slither, address, chain)
-    root_contracts = _select_local_root_contracts(slither)
+    root_contracts = _merge_root_contracts(
+        resolved_contracts,
+        _select_local_root_contracts(slither),
+    )
     if not root_contracts:
         raise ValueError("No deployable contracts found for the address")
 


### PR DESCRIPTION
- add env-driven custom template selection while keeping template.html as the default
- document TEMPLATE_PATH and ignore local-only/ for user-local templates and scratch files
- preserve the deployed contract when merging root contracts from on-chain verification bundles
