### PR TITLE
Fix duplicate inherited entry points

### DIFF
--- a/analysis/entry_points.py
+++ b/analysis/entry_points.py
@@ -1,0 +1,74 @@
+"""Helpers for enumerating entry points without duplicate inherited callables."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Sequence, Set
+
+
+def entry_point_identity(entry_point: Any) -> tuple[Any, ...]:
+    """
+    Build a stable per-run identity for an entry point.
+
+    The same inherited callable can surface while iterating both a root contract and one of its
+    concrete bases. Prefer a semantic key based on declarer + source mapping so we can drop the
+    duplicate without losing distinct overloads or overrides.
+    """
+    source_mapping = getattr(entry_point, "source_mapping", None)
+    filename = ""
+    start = None
+    length = None
+    if source_mapping is not None:
+        filename_obj = getattr(source_mapping, "filename", None)
+        filename = (
+            getattr(filename_obj, "absolute", "")
+            or getattr(filename_obj, "relative", "")
+            or getattr(filename_obj, "short", "")
+            or str(filename_obj or "")
+        )
+        raw_start = getattr(source_mapping, "start", None)
+        raw_length = getattr(source_mapping, "length", None)
+        start = raw_start if isinstance(raw_start, int) else None
+        length = raw_length if isinstance(raw_length, int) else None
+
+    declarer = getattr(entry_point, "contract_declarer", None) or getattr(entry_point, "contract", None)
+    declarer_name = getattr(declarer, "name", "") or ""
+    signature = (
+        getattr(entry_point, "solidity_signature", None)
+        or getattr(entry_point, "full_name", None)
+        or getattr(entry_point, "name", None)
+        or "<unknown>"
+    )
+
+    if filename or start is not None or length is not None:
+        return (
+            declarer_name,
+            signature,
+            filename,
+            start,
+            length,
+        )
+
+    return (
+        declarer_name,
+        signature,
+        id(entry_point),
+    )
+
+
+def collect_unique_entry_points(
+    contracts: Sequence[Any],
+    entry_points_fn: Callable[[Any], List[Any]],
+) -> List[tuple[Any, List[Any]]]:
+    """Collect entry points once even if inherited functions surface on multiple contracts."""
+    seen: Set[tuple[Any, ...]] = set()
+    result: List[tuple[Any, List[Any]]] = []
+    for contract in contracts:
+        unique_for_contract: List[Any] = []
+        for entry_point in entry_points_fn(contract):
+            key = entry_point_identity(entry_point)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique_for_contract.append(entry_point)
+        result.append((contract, unique_for_contract))
+    return result

--- a/analysis/flow_walk.py
+++ b/analysis/flow_walk.py
@@ -26,6 +26,7 @@ from slither.slither import Slither
 from slither.utils.code_complexity import compute_cyclomatic_complexity
 from slither.utils.tests_pattern import is_test_file
 
+from analysis.entry_points import collect_unique_entry_points
 from analysis.slither_extract import (
     _contract_key,
     _display_name,
@@ -1212,10 +1213,11 @@ def _build_entry_point_flows(
         "Collecting audited contracts",
         count=len(audited_contracts),
     )
-    total_entries = sum(len(entry_points_fn(contract)) for contract in audited_contracts)
+    contract_entry_points = collect_unique_entry_points(audited_contracts, entry_points_fn)
+    total_entries = sum(len(entry_points) for _, entry_points in contract_entry_points)
     entry_index = 0
 
-    for contract_index, contract in enumerate(audited_contracts, start=1):
+    for contract_index, (contract, entry_points) in enumerate(contract_entry_points, start=1):
         _report_progress(
             progress_cb,
             "Scanning contract",
@@ -1223,7 +1225,7 @@ def _build_entry_point_flows(
             index=contract_index,
             total=len(audited_contracts),
         )
-        for entry_point in entry_points_fn(contract):
+        for entry_point in entry_points:
             entry_index += 1
             _report_progress(
                 progress_cb,

--- a/template.html
+++ b/template.html
@@ -1648,8 +1648,26 @@
       return JSON.stringify(stable);
     };
 
+    const dedupeRenderedEntries = (entries = []) => {
+      const seen = new Set();
+      return entries.filter((entry, idx) => {
+        const flow = Array.isArray(entry?.flow) ? entry.flow : [];
+        const head = flow[0] || {};
+        const key = JSON.stringify([
+          entry?.entry_point || `entry_point_${idx}`,
+          head?.contract || '',
+          head?.source || '',
+          flow.length
+        ]);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    };
+
 		    const buildDataFromJson = (entries = []) => {
-		      const functions = entries.map((entry, idx) => {
+		      const uniqueEntries = dedupeRenderedEntries(entries);
+		      const functions = uniqueEntries.map((entry, idx) => {
 		        const id = normalizeId(entry.entry_point || `fn_${idx}`, `id${idx}`);
 		        const fullName = entry.entry_point || `entry_point_${idx}`;
 		        const display = fullName.split('(')[0];
@@ -1669,7 +1687,7 @@
       const graphs = {};
       const stateReads = {};
       const stateWrites = {};
-      entries.forEach((entry, idx) => {
+      uniqueEntries.forEach((entry, idx) => {
         const flow = entry.flow || [];
         const entryMsgSenderChecks = Array.isArray(entry?.msg_sender_checks) ? entry.msg_sender_checks : [];
         const entryMsgSenderRestrictions = Array.isArray(entry?.msg_sender_restrictions) ? entry.msg_sender_restrictions : [];

--- a/tests/test_flow_walk_entry_points.py
+++ b/tests/test_flow_walk_entry_points.py
@@ -1,0 +1,77 @@
+import unittest
+from types import SimpleNamespace
+
+from analysis.entry_points import collect_unique_entry_points
+
+
+class _FakeContract:
+    def __init__(self, name, entry_points):
+        self.name = name
+        self.entry_points = list(entry_points)
+
+
+def _fake_entry_point(declarer_name, signature, *, filename, start, length):
+    declarer = SimpleNamespace(name=declarer_name)
+    source_mapping = SimpleNamespace(
+        filename=SimpleNamespace(absolute=filename, relative=filename, short=filename),
+        start=start,
+        length=length,
+    )
+    return SimpleNamespace(
+        contract_declarer=declarer,
+        contract=declarer,
+        solidity_signature=signature,
+        full_name=signature,
+        name=signature.split("(", 1)[0],
+        source_mapping=source_mapping,
+    )
+
+
+class CollectUniqueEntryPointsTests(unittest.TestCase):
+    def test_dedupes_inherited_entry_points_seen_on_base_and_root(self):
+        approve = _fake_entry_point(
+            "ERC20",
+            "approve(address,uint256)",
+            filename="IpToken.sol",
+            start=100,
+            length=25,
+        )
+        base = _FakeContract("ERC20", [approve])
+        root = _FakeContract("IpToken", [approve])
+
+        result = collect_unique_entry_points(
+            [base, root],
+            lambda contract: contract.entry_points,
+        )
+
+        self.assertEqual([entry for _, entries in result for entry in entries], [approve])
+        self.assertEqual(result[0][1], [approve])
+        self.assertEqual(result[1][1], [])
+
+    def test_preserves_distinct_overloads(self):
+        approve_no_data = _fake_entry_point(
+            "ERC20",
+            "approve(address,uint256)",
+            filename="IpToken.sol",
+            start=100,
+            length=25,
+        )
+        approve_with_data = _fake_entry_point(
+            "ERC20",
+            "approve(address,uint256,bytes)",
+            filename="IpToken.sol",
+            start=140,
+            length=32,
+        )
+        contract = _FakeContract("ERC20", [approve_no_data, approve_with_data])
+
+        result = collect_unique_entry_points(
+            [contract],
+            lambda current: current.entry_points,
+        )
+
+        self.assertEqual(result[0][1], [approve_no_data, approve_with_data])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- dedupe inherited entry points in the backend flow builder before rendering
- add a template-side guard so duplicate payload rows do not render twice
- add regression tests for inherited duplicates and overload preservation

## Why
- some inherited entry points were being emitted twice into the same contract view, which caused duplicate rows in the left panel
